### PR TITLE
Adding timezone to getDateTimeFromString to fix invalid time during DST

### DIFF
--- a/src/sysheaders.h
+++ b/src/sysheaders.h
@@ -33,6 +33,7 @@
 #include <QSqlQuery>
 #include <QSqlError>
 #include <QDateTime>
+#include <QTimeZone>
 #include <QTimeEdit>
 #include <QGroupBox>
 #include <QCheckBox>

--- a/src/webservice.cpp
+++ b/src/webservice.cpp
@@ -735,13 +735,14 @@ QString AWebservice::getNextBlock (const QString* source, const QString& from, c
 	return result;
 }
 //----------------------------------------------------------------------------------------------
-
+static QTimeZone moscow("Europe/Moscow");
 QDateTime AWebservice::getDateTimeFromString (const QString& value)
 {
-	if (value == "0001-01-01T00:00:00")
-		return QDateTime::fromString("1970-01-01T00:00:00", Qt::ISODate);
-
-	return QDateTime::fromString(value, Qt::ISODate);
+	QDateTime dt = (value == "0001-01-01T00:00:00") ?
+		QDateTime::fromString("1970-01-01T00:00:00", Qt::ISODate):
+		QDateTime::fromString(value, Qt::ISODate);
+	dt.setTimeZone(moscow);
+	return dt;
 }
 //----------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Антон,
PR чинит проблему с переходом с/на летнее время в других временных зонах. По хорошему надо чтобы сервер клал TZ, но я пока захардкодил в Москву.
Спасибо, novitk

In [32]: d = QtCore.QDateTime.fromString("2012-03-11T02:09:58.883", Qt.DateFormat.ISODate)
In [33]: d.isValid()
Out[33]: False
In [23]: d.timeZone()
Out[23]: <PySide6.QtCore.QTimeZone("America/New_York") at 0x7fbe494b3b80>
In [34]: d.setTimeZone(QtCore.QTimeZone(b"Europe/Moscow"))
In [35]: d.isValid()
Out[35]: True
